### PR TITLE
Preserves the original FieldInfo

### DIFF
--- a/news/15.bugfix
+++ b/news/15.bugfix
@@ -1,0 +1,5 @@
+Preserves the original FieldInfo when resolving nested extended classes at
+registry initialization time. Before this change, when the registry was
+initialized, and a field referencing a nested class was encountered, only
+the annotated information was preserved not the additional information provided
+as default value.

--- a/src/extendable_pydantic/main.py
+++ b/src/extendable_pydantic/main.py
@@ -99,7 +99,7 @@ class ExtendableModelMeta(ExtendableMeta, ModelMetaclass):
                 if not all_identical(field_info.annotation, new_type):
                     cast(BaseModel, cls).model_fields[
                         field_name
-                    ] = FieldInfo.from_annotation(new_type)
+                    ] = FieldInfo.merge_field_infos(field_info, annotation=new_type)
                     to_rebuild = True
         if to_rebuild:
             delattr(cls, "__pydantic_core_schema__")


### PR DESCRIPTION
Preserves the original FieldInfo when resolving nested extended classes at registry initialization time.

fixes #15