### PR TITLE
Ensure recursive field annotation resolution

### DIFF
--- a/news/19.bugfix
+++ b/news/19.bugfix
@@ -1,0 +1,39 @@
+Fix problem with unresolved annotated types in the aggregated model.
+
+At the end of the registry building process, the registry contains the aggregated
+model. Each aggregated model is the result of the build of a new class based on
+a hierarchy of all the classes defined as 'extends' of the same base class. The
+order of the classes hierarchy is defined by the order in which the classes are
+loaded by the class loader or by a specific order defined by the developer when
+the registry is built.
+
+The last step of the build process is to resolve all the annotated types in the
+aggregated model and rebuild the pydantic schema validator. This step is necessary
+because when the developer defines a model, some fields can be annotated with a
+type that refers to a class that is an extendable class. It's therefore necessary
+to update the annotated type with the aggregated result of the specified
+extendable class and rebuild the pydantic schema validator to take into account
+the new annotated types.
+
+Prior to this commit, the resolution of the annotated types was not done in a
+recursive way and the rebuild of the pydantic schema validator was only done
+just after the resolution of an aggregated class. This means that if a class A
+is an extendable defining a fields annotated with a type that refers to a class
+B, and if the class B is an extendable class defining a field of type C,
+the annotated type of the field of the class A was resolved with the aggregated
+model of the class B but we didn't resolve th annotated type of the field ot type
+B with the aggregated model of the type C. Therefore when the pydantic schema
+validator was rebuilt after the resolution of the class A, if the class B was
+not yet resolved and therefore the pydantic schema validator was not rebuilt,
+the new schema validator for the class A was not correct because it didn't take
+into account the aggregated model of the class C nor the definition of extra
+fields of the aggregated model of the class B.
+
+This commit changes the resolution of the annotated types to be recursive. Therefore
+when the pydantic schema validator is rebuilt, we are sure that all referenced
+subtypes are resolved and defines a correct schema validator. In the
+same time, when an aggregated class is resolved, it's marked as resolved to avoid
+to resolve it again and rebuild the pydantic schema validator again for nothing.
+In addition to resolve the initial problem, this commit also improves
+the performance of the build process because schema validators rebuilds are
+done only once per aggregated class.

--- a/src/extendable_pydantic/main.py
+++ b/src/extendable_pydantic/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import typing
 import warnings
-from typing import Any, Dict, List, Optional, cast, no_type_check, Set
+from typing import Any, Dict, List, Optional, cast, no_type_check
 
 from extendable import context, main
 from extendable.main import ExtendableMeta
@@ -28,6 +28,8 @@ if typing.TYPE_CHECKING:
 
 
 class ExtendableModelMeta(ExtendableMeta, ModelMetaclass):
+    __xreg_fields_resolved__: bool = False
+
     @no_type_check
     @classmethod
     def _build_original_class(metacls, name, bases, namespace, **kwargs):
@@ -45,6 +47,7 @@ class ExtendableModelMeta(ExtendableMeta, ModelMetaclass):
         namespace = super()._prepare_namespace(
             name=name, bases=bases, namespace=namespace, extends=extends, **kwargs
         )
+        namespace["__xreg_fields_resolved__"] = False
         return namespace
 
     @no_type_check
@@ -93,13 +96,9 @@ class ExtendableModelMeta(ExtendableMeta, ModelMetaclass):
         """Replace the original field type into the definition of the field by the one
         from the registry."""
         registry = registry if registry else context.extendable_registry.get()
-        resolved: Set["ExtendableModelMeta"] = getattr(
-            registry, "_resolved_models", set()
-        )
-        if cls in resolved:
+        if cls.__xreg_fields_resolved__:
             return
-        resolved.add(cls)
-        registry._resolved_models = resolved  # type: ignore[union-attr]
+        cls.__xreg_fields_resolved__ = True
         to_rebuild = False
         if issubclass(cls, BaseModel):
             for field_name, field_info in cast(BaseModel, cls).model_fields.items():
@@ -117,7 +116,6 @@ class ExtendableModelMeta(ExtendableMeta, ModelMetaclass):
 class RegistryListener(ExtendableRegistryListener):
     def on_registry_initialized(self, registry: ExtendableClassesRegistry) -> None:
         self.resolve_submodel_fields(registry)
-        self.rebuild_models(registry)
 
     def before_init_registry(
         self,
@@ -129,10 +127,6 @@ class RegistryListener(ExtendableRegistryListener):
             # prepend the current module to the module_matchings
             if "extendable_pydantic" not in module_matchings:
                 module_matchings.insert(0, "extendable_pydantic.models")
-
-    def rebuild_models(self, registry: ExtendableClassesRegistry) -> None:
-        for cls in registry._extendable_classes.values():
-            cast(BaseModel, cls).model_rebuild(force=True)
 
     def resolve_submodel_fields(self, registry: ExtendableClassesRegistry) -> None:
         for cls in registry._extendable_classes.values():

--- a/src/extendable_pydantic/utils.py
+++ b/src/extendable_pydantic/utils.py
@@ -113,7 +113,10 @@ def resolve_annotation(
     # semantics as "typing" classes or generic aliases
 
     if not origin_type and issubclass(type(type_), ExtendableMeta):
-        return type_._get_assembled_cls(registry)
+        final_type = type_._get_assembled_cls(registry)
+        if final_type is not type_:
+            final_type._resolve_submodel_fields(registry)
+        return final_type
 
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.


### PR DESCRIPTION
At the end of the registry building process, the registry contains the aggregated
model. Each aggregated model is the result of the build of a new class based on
a hierarchy of all the classes defined as 'extends' of the same base class. The
order of the classes hierarchy is defined by the order in which the classes are
loaded by the class loader or by a specific order defined by the developer when
the registry is built.

The last step of the build process is to resolve all the annotated types in the
aggregated model and rebuild the pydantic schema validator. This step is necessary
because when the developer defines a model, some fields can be annotated with a
type that refers to a class that is an extendable class. It's therefore necessary
to update the annotated type with the aggregated result of the specified
extendable class and rebuild the pydantic schema validator to take into account
the new annotated types.

Prior to this commit, the resolution of the annotated types was not done in a
recursive way and the rebuild of the pydantic schema validator was only done
just after the resolution of an aggregated class. This means that if a class A
is an extendable defining a fields annotated with a type that refers to a class
B, and if the class B is an extendable class defining a field of type C,
the annotated type of the field of the class A was resolved with the aggregated
model of the class B but we didn't resolve th annotated type of the field ot type
B with the aggregated model of the type C. Therefore when the pydantic schema
validator was rebuilt after the resolution of the class A, if the class B was
not yet resolved and therefore the pydantic schema validator was not rebuilt,
the new schema validator for the class A was not correct because it didn't take
into account the aggregated model of the class C nor the definition of extra
fields of the aggregated model of the class B.

This commit changes the resolution of the annotated types to be recursive. Therefore
when the pydantic schema validator is rebuilt, we are sure that all referenced
subtypes are resolved and defines a correct schema validator. In the
same time, when an aggregated class is resolved, it's marked as resolved to avoid
to resolve it again and rebuild the pydantic schema validator again for nothing.
In addition to resolve the initial problem, this commit also improves
the performance of the build process because schema validators rebuilds are
done only once per aggregated class.