### PR TITLE
Check FastAPI version and apply appropriate method for function wrapping

### DIFF
--- a/src/extendable_pydantic/_patch.py
+++ b/src/extendable_pydantic/_patch.py
@@ -66,12 +66,13 @@ def hook_fastapi_utils(utils):
         _resolve_model_fields_annotation([field])
         return field
 
-    # fastapi <  0.112.3
-    wrapt.wrap_function_wrapper(
-        utils, "create_response_field", _create_response_field_wrapper
-    )
-
-    # fastapi >= 0.112.3
-    wrapt.wrap_function_wrapper(
-        utils, "create_model_field", _create_response_field_wrapper
-    )
+    if hasattr(utils, "create_response_field"):
+        # For fastapi < 0.112.3
+        wrapt.wrap_function_wrapper(
+            utils, "create_response_field", _create_response_field_wrapper
+        )
+    if hasattr(utils, "create_model_field"):
+        # For fastapi >= 0.112.3
+        wrapt.wrap_function_wrapper(
+            utils, "create_model_field", _create_response_field_wrapper
+        )


### PR DESCRIPTION
This commit introduces a check for `FastAPI/utils` to apply the appropriate method for function wrapping, addressing compatibility issues as discussed in [extendable-pydantic issue #20](https://github.com/lmignon/extendable-pydantic/issues/20).

Despite using `extendable_pydantic==1.3.1` and `fastapi==0.114.1`, the issue still persists.
```
odoo-1          | 2024-09-12 05:02:23,349 91 CRITICAL odoodb odoo.modules.module: Couldn't load module fastapi
odoo-1          | 2024-09-12 05:02:23,349 91 CRITICAL odoodb odoo.modules.module: partially initialized module 'fastapi.utils' has no attribute 'create_response_field' (most likely due to a circular import)
odoo-1          | 2024-09-12 05:02:23,356 91 WARNING odoodb odoo.modules.loading: Transient module states were reset
odoo-1          | 2024-09-12 05:02:23,359 91 ERROR odoodb odoo.modules.registry: Failed to load registry
odoo-1          | Traceback (most recent call last):
odoo-1          |   File "/odoo/src/odoo/modules/registry.py", line 90, in new
odoo-1          |     odoo.modules.load_modules(registry, force_demo, status, update_module)
odoo-1          |   File "/odoo/src/odoo/modules/loading.py", line 488, in load_modules
odoo-1          |     processed_modules += load_marked_modules(cr, graph,
odoo-1          |   File "/odoo/src/odoo/modules/loading.py", line 372, in load_marked_modules
odoo-1          |     loaded, processed = load_module_graph(
odoo-1          |   File "/odoo/src/odoo/modules/loading.py", line 188, in load_module_graph
odoo-1          |     load_openerp_module(package.name)
odoo-1          |   File "/odoo/src/odoo/modules/module.py", line 471, in load_openerp_module
odoo-1          |     __import__('odoo.addons.' + module_name)
odoo-1          |   File "/odoo/external-src/rest-framework/fastapi/__init__.py", line 1, in <module>
odoo-1          |     from . import models
odoo-1          |   File "/odoo/external-src/rest-framework/fastapi/models/__init__.py", line 1, in <module>
odoo-1          |     from .fastapi_endpoint import FastapiEndpoint
odoo-1          |   File "/odoo/external-src/rest-framework/fastapi/models/fastapi_endpoint.py", line 15, in <module>
odoo-1          |     from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, Response
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/fastapi/__init__.py", line 7, in <module>
odoo-1          |     from .applications import FastAPI as FastAPI
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 16, in <module>
odoo-1          |     from fastapi import routing
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 35, in <module>
odoo-1          |     from fastapi.dependencies.utils import (
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/fastapi/dependencies/utils.py", line 59, in <module>
odoo-1          |     from fastapi.utils import create_model_field, get_path_param_names
odoo-1          |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
odoo-1          |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
odoo-1          |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/importer.py", line 177, in _exec_module
odoo-1          |     notify_module_loaded(module)
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/decorators.py", line 470, in _synchronized
odoo-1          |     return wrapped(*args, **kwargs)
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/importer.py", line 136, in notify_module_loaded
odoo-1          |     hook(module)
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/extendable_pydantic/_patch.py", line 70, in hook_fastapi_utils
odoo-1          |     wrapt.wrap_function_wrapper(
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/wrappers.py", line 870, in wrap_function_wrapper
odoo-1          |     return wrap_object(module, name, FunctionWrapper, (wrapper,))
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/wrappers.py", line 816, in wrap_object
odoo-1          |     (parent, attribute, original) = resolve_path(module, name)
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/wrappers.py", line 804, in resolve_path
odoo-1          |     original = lookup_attribute(parent, attribute)
odoo-1          |   File "/usr/local/lib/python3.10/site-packages/wrapt/wrappers.py", line 802, in lookup_attribute
odoo-1          |     return getattr(parent, attribute)
odoo-1          | AttributeError: partially initialized module 'fastapi.utils' has no attribute 'create_response_field' (most likely due to a circular import). Did you mean: 'create_cloned_field'?
odoo-1          | 2024-09-12 05:02:23,369 91 CRITICAL odoodb odoo.service.server: Failed to initialize database 