### PR TITLE
Force the use of extendable>=1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v3.0.1
 
   tests:
     name: "Python ${{ matrix.python-version }}"
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.7"
-            machine: ubuntu-22.04
           - python-version: "3.8"
             machine: ubuntu-22.04
           - python-version: "3.9"
@@ -32,6 +30,8 @@ jobs:
           - python-version: "3.11"
             machine: ubuntu-22.04
           - python-version: "3.12"
+            machine: ubuntu-22.04
+          - python-version: "3.13"
             machine: ubuntu-22.04
     steps:
       - uses: "actions/checkout@v3"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,8 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+  - repo: https://github.com/PyCQA/docformatter
+    rev: eb1df347edd128b30cd3368dddc3aa65edcfac38
     hooks:
       - id: docformatter
         args: ["--in-place", "--wrap-summaries=88"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dynamic = ["version", "description"]
 dependencies = [
-    "extendable>=1.2.0",
+    "extendable>=1.3.0",
     "pydantic>=2.0.2",
     "wrapt",
 ]

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,0 +1,182 @@
+"""Test Union."""
+
+import sys
+from typing import Union, Any, Optional
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
+from pydantic import Tag, Discriminator
+from pydantic.main import BaseModel
+
+from extendable_pydantic import ExtendableModelMeta
+
+from pytest import fixture
+
+
+@fixture
+def model_union_base_models():
+    class Coordinate(
+        BaseModel,
+        metaclass=ExtendableModelMeta,
+        revalidate_instances="always",
+        validate_assignment=True,
+    ):
+        lat: float = 0.1
+        lng: float = 10.1
+
+    class CoordinateWithCountry(Coordinate):
+        country: str = None
+
+    def _test_discriminate_coordinate_type(v: Any) -> Optional[str]:
+        if isinstance(v, CoordinateWithCountry):
+            return "coordinate_with_country"
+        if isinstance(v, Coordinate):
+            return "coordinate"
+        if isinstance(v, dict):
+            if "country" in v:
+                return "coordinate_with_country"
+            if "lat" in v:
+                return "coordinate"
+        return None
+
+    class Person(
+        BaseModel,
+        metaclass=ExtendableModelMeta,
+        revalidate_instances="always",
+        validate_assignment=True,
+    ):
+        name: str
+        coordinate: Optional[
+            Annotated[
+                Union[
+                    Annotated[Coordinate, Tag("coordinate")],
+                    Annotated[CoordinateWithCountry, Tag("coordinate_with_country")],
+                ],
+                Discriminator(_test_discriminate_coordinate_type),
+            ]
+        ] = None
+
+    return Person, Coordinate, CoordinateWithCountry
+
+
+@fixture
+def model_union_models(model_union_base_models):
+    Person, Coordinate, CoordinateWithCountry = model_union_base_models
+
+    class ExtendedCoordinate(Coordinate, extends=Coordinate):
+        state: str = None
+
+    class ExtendedCoordinateWithCountry(
+        CoordinateWithCountry, extends=CoordinateWithCountry
+    ):
+        currency: str = None
+
+    return (
+        Person,
+        Coordinate,
+        ExtendedCoordinate,
+        CoordinateWithCountry,
+        ExtendedCoordinateWithCountry,
+    )
+
+
+def test_model_union(model_union_models, test_registry):
+
+    (
+        Person,
+        Coordinate,
+        ExtendedCoordinate,
+        CoordinateWithCountry,
+        _ExtendedCoordinateWithCountry,
+    ) = model_union_models
+    test_registry.init_registry()
+    ClsPerson = test_registry[Person.__xreg_name__]
+    # check that the behaviour is the same for all the definitions
+    # of the same model...
+    classes = Person, ClsPerson
+    for cls in classes:
+        person = cls(
+            name="test",
+            coordinate={
+                "lng": 5.0,
+                "lat": 4.2,
+                "country": "belgium",
+                "state": "brussels",
+                "currency": "euro",
+            },
+        )
+        coordinate = person.coordinate
+        assert isinstance(coordinate, CoordinateWithCountry)
+        person = cls(
+            name="test",
+            coordinate={"lng": 5.0, "lat": 4.2, "state": "brussels"},
+        )
+        coordinate = person.coordinate
+        assert isinstance(coordinate, Coordinate)
+
+        # sub schema are stored into the definition property
+        definitions = ClsPerson.model_json_schema().get("$defs", {})
+        assert "Coordinate" in definitions
+        coordinate_properties = definitions["Coordinate"].get("properties", {}).keys()
+        assert {"lat", "lng", "state"} == set(coordinate_properties)
+        assert "CoordinateWithCountry" in definitions
+        coordinate_with_country_properties = (
+            definitions["CoordinateWithCountry"].get("properties", {}).keys()
+        )
+        assert {"lat", "lng", "country", "state", "currency"} == set(
+            coordinate_with_country_properties
+        )
+
+    person = Person(
+        name="test",
+        coordinate=Coordinate(
+            lat=5.0,
+            lng=4.2,
+            state="brussels",
+        ),
+    )
+    assert isinstance(person.coordinate, Coordinate)
+    assert isinstance(person.coordinate, ExtendedCoordinate)
+    assert person.model_dump(mode="python") == {
+        "name": "test",
+        "coordinate": {"lat": 5.0, "lng": 4.2, "state": "brussels"},
+    }
+
+    person = Person(
+        name="test",
+        coordinate=ExtendedCoordinate(
+            lat=5.0,
+            lng=4.2,
+            state="brussels",
+        ),
+    )
+    assert isinstance(person.coordinate, Coordinate)
+    assert isinstance(person.coordinate, ExtendedCoordinate)
+
+
+def test_union_validate_on_assign(model_union_base_models, test_registry):
+    # covers issue https://github.com/lmignon/extendable/issues/18
+    Person, Coordinate, CoordinateWithCountry = model_union_base_models
+    test_registry.init_registry()
+    ClsPerson = test_registry[Person.__xreg_name__]
+    # check that the behaviour is the same for all the definitions
+    # of the same model...
+    classes = Person, ClsPerson
+    for cls in classes:
+        person = cls(
+            name="test",
+        )
+        person.coordinate = CoordinateWithCountry(
+            lng=5.0, lat=4.2, country="belgium", state="brussels", currency="euro"
+        )
+        coordinate = person.coordinate
+        assert isinstance(coordinate, CoordinateWithCountry)
+        person = cls(
+            name="test",
+            coordinate={"lng": 5.0, "lat": 4.2, "state": "brussels"},
+        )
+        coordinate = person.coordinate
+        assert isinstance(coordinate, Coordinate)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [gh-actions]
 python =
-    3.7: py37, typing
     3.8: py38, typing
     3.9: py39, typing, pypi-description
     3.10: py310, typing
     3.11: py311, typing
     3.12: py312, typing
+    3.13: py313, typing
     pypi-description: pypi-description
 
 [tox]
@@ -17,6 +17,7 @@ envlist =
     py310
     py311
     py312
+    py313
     lint
     typing
     pypi-description


### PR DESCRIPTION
This is required to avoid a bug in some pydantic methods when a instance is checked against its own type and the result was wrongly returned as False

see https://github.com/lmignon/extendable/issues/18